### PR TITLE
Feature/#2 setup redis session clustering

### DIFF
--- a/src/main/java/org/sesac/market/config/RedisSessionClusterConfig.java
+++ b/src/main/java/org/sesac/market/config/RedisSessionClusterConfig.java
@@ -1,0 +1,91 @@
+package org.sesac.market.config;
+
+import io.lettuce.core.SocketOptions;
+import io.lettuce.core.cluster.ClusterClientOptions;
+import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisClusterConfiguration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisNode;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisOperations;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.security.core.session.SessionRegistry;
+import org.springframework.session.data.redis.RedisIndexedSessionRepository;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+import org.springframework.session.security.SpringSessionBackedSessionRegistry;
+
+import java.time.Duration;
+import java.util.List;
+
+@Configuration
+@EnableRedisRepositories
+@EnableRedisHttpSession
+@RequiredArgsConstructor
+public class RedisSessionClusterConfig {
+    private final RedisSessionClusterProperties properties;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        final List<String> nodes = properties.getNodes();
+        final String password = properties.getPassword();
+        final int maxRedirects = properties.getMaxRedirects();
+        final List<RedisNode> redisNodes = nodes.stream()
+                .map(node -> new RedisNode(node.split(":")[0], Integer.parseInt(node.split(":")[1])))
+                .toList();
+
+        // 1. Redis Cluster 설정
+        var config = new RedisClusterConfiguration();
+        config.setClusterNodes(redisNodes);
+        config.setMaxRedirects(maxRedirects);
+        config.setPassword(password);
+
+        // 2. Socket 옵션 설정
+        var socketOptions = SocketOptions.builder()
+                .connectTimeout(Duration.ofMillis(100L))
+                .keepAlive(true)
+                .build();
+
+        // 3. Cluster Topology Refresh 옵션 설정
+        var clusterTopologyRefreshOptions = ClusterTopologyRefreshOptions.builder()
+                .dynamicRefreshSources(true)
+                .enableAllAdaptiveRefreshTriggers()
+                .enablePeriodicRefresh(Duration.ofMinutes(30L))
+                .build();
+
+        // 4. Lettuce Client 옵션 설정
+        var clientOptions = ClusterClientOptions.builder()
+                .topologyRefreshOptions(clusterTopologyRefreshOptions)
+                .socketOptions(socketOptions)
+                .build();
+
+        // 5. Lettuce Client 설정
+        var clientConfiguration = LettuceClientConfiguration.builder()
+                .clientOptions(clientOptions)
+                .commandTimeout(Duration.ofMillis(3000L))
+                .build();
+
+        return new LettuceConnectionFactory(config, clientConfiguration);
+    }
+
+    @Bean
+    public RedisOperations<String, Object> sessionRedisOperations(RedisConnectionFactory redisConnectionFactory) {
+        var redisTemplate = new RedisTemplate<String, Object>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory);
+        return redisTemplate;
+    }
+
+    @Bean
+    public SessionRegistry springSessionBackedSessionRegistry(RedisIndexedSessionRepository redisIndexedSessionRepository) {
+        return new SpringSessionBackedSessionRegistry<>(redisIndexedSessionRepository);
+    }
+
+    @Bean
+    public RedisIndexedSessionRepository sessionRepository(RedisOperations<String, Object> sessionRedisOperations) {
+        return new RedisIndexedSessionRepository(sessionRedisOperations);
+    }
+}

--- a/src/main/java/org/sesac/market/config/RedisSessionClusterProperties.java
+++ b/src/main/java/org/sesac/market/config/RedisSessionClusterProperties.java
@@ -1,0 +1,16 @@
+package org.sesac.market.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis.cluster")
+public class RedisSessionClusterProperties {
+    private String password;
+    private int maxRedirects;
+    private List<String> nodes;
+}

--- a/src/main/java/org/sesac/market/config/RedisSessionStandaloneConfig.java
+++ b/src/main/java/org/sesac/market/config/RedisSessionStandaloneConfig.java
@@ -1,8 +1,10 @@
 package org.sesac.market.config;
 
-import org.springframework.beans.factory.annotation.Value;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisPassword;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
@@ -15,29 +17,23 @@ import org.springframework.session.data.redis.RedisIndexedSessionRepository;
 import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
 import org.springframework.session.security.SpringSessionBackedSessionRegistry;
 
+@Deprecated
+@Profile("deprecated")
+@Description("단일 redis 를 사용하고 싶으시다면 클러스터 설정을 해제하고 이것을 사용하세요.")
 @Configuration
+@RequiredArgsConstructor
 @EnableRedisRepositories
 @EnableRedisHttpSession
-public class RedisSessionConfig {
-    @Value("${spring.data.redis.host}")
-    private String host;
-
-    @Value("${spring.data.redis.port}")
-    private int port;
-
-    @Value("${spring.data.redis.username}")
-    private String username;
-
-    @Value("${spring.data.redis.password}")
-    private String password;
+public class RedisSessionStandaloneConfig {
+    private final RedisSessionStandaloneProperties properties;
 
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         RedisStandaloneConfiguration configuration = new RedisStandaloneConfiguration();
-        configuration.setHostName(host);
-        configuration.setPort(port);
-        configuration.setUsername(username);
-        configuration.setPassword(RedisPassword.of(password));
+        configuration.setHostName(properties.getHost());
+        configuration.setPort(properties.getPort());
+        configuration.setUsername(properties.getUsername());
+        configuration.setPassword(RedisPassword.of(properties.getPassword()));
         return new LettuceConnectionFactory(configuration);
     }
 

--- a/src/main/java/org/sesac/market/config/RedisSessionStandaloneProperties.java
+++ b/src/main/java/org/sesac/market/config/RedisSessionStandaloneProperties.java
@@ -1,0 +1,20 @@
+package org.sesac.market.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Description;
+import org.springframework.context.annotation.Profile;
+
+@Deprecated
+@Profile("deprecated")
+@Description("단일 redis 를 사용하고 싶으시다면 클러스터 설정을 해제하고 이것을 사용하세요.")
+@Data
+@Configuration
+@ConfigurationProperties(prefix = "spring.data.redis")
+public class RedisSessionStandaloneProperties {
+    private String host;
+    private int port;
+    private String username;
+    private String password;
+}

--- a/src/main/resources/config/database.yml
+++ b/src/main/resources/config/database.yml
@@ -10,13 +10,6 @@ spring:
         url: jdbc:mysql://${ACCOUNT_DB_REPLICA_HOST:localhost}:${ACCOUNT_DB_REPLICA_PORT:3318}/${ACCOUNT_DB_REPLICA_DATABASE:product}
         username: ${ACCOUNT_DB_REPLICA_USER:root}
         password: ${ACCOUNT_DB_REPLICA_PASSWORD:root}
-  data:
-    redis:
-      host: ${REDISHOST}
-      username: ${REDISUSER}
-      password: ${REDISPASSWORD}
-      port: ${REDISPORT}
-
   jpa:
     show-sql: true
     hibernate:

--- a/src/main/resources/config/session.yml
+++ b/src/main/resources/config/session.yml
@@ -4,3 +4,20 @@ spring:
   session:
     redis:
       namespace: market:session
+  data:
+    redis:
+      #host: ${REDISHOST}
+      #username: ${REDISUSER}
+      #password: ${REDISPASSWORD}
+      #port: ${REDISPORT}
+      cluster:
+        max-redirects: ${REDIS_CLUSTER_MAX_REDIRECTS:3}
+        nodes:
+          - ${REDIS_CLUSTER_NODE_1_HOST}:${REDIS_CLUSTER_NODE_1_PORT}
+          - ${REDIS_CLUSTER_NODE_2_HOST}:${REDIS_CLUSTER_NODE_2_PORT}
+          - ${REDIS_CLUSTER_NODE_3_HOST}:${REDIS_CLUSTER_NODE_3_PORT}
+          - ${REDIS_CLUSTER_NODE_4_HOST}:${REDIS_CLUSTER_NODE_4_PORT}
+          - ${REDIS_CLUSTER_NODE_5_HOST}:${REDIS_CLUSTER_NODE_5_PORT}
+          - ${REDIS_CLUSTER_NODE_6_HOST}:${REDIS_CLUSTER_NODE_6_PORT}
+        password: ${REDIS_CLUSTER_PASSWORD:}
+      timeout: 500ms


### PR DESCRIPTION
## 변경사항

redis cluster 반영

### Issue Link 
- https://github.com/cloud2scape/core-gateway/issues/2


## 체크리스트

리뷰 요청 전에 확인해야 할 사항들을 나열해주세요.

- [x] 로컬 싱글 세션으로 다시 전환할 수 있도록 설계했나요?
- [x] 로컬 kubespray, eks 에서도 정상 동작하나요?

## 참고
배포된 서비스의 account(접근시 인증 필수) 조회 결과
![스크린샷 2024-11-22 212458](https://github.com/user-attachments/assets/4bd29677-94fd-4001-8d38-e0e1944afd7c)


배포 이후 상태 조회
```powershell
~\IdeaProjects\terraform git:[main]
kubectl get all -o wide
NAME                                   READY   STATUS    RESTARTS   AGE     IP           NODE                                            NOMINATED NODE   READINESS GATES
pod/core-gateway-6c8cddf88f-ms6t6      1/1     Running   0          3h24m   10.0.2.147   ip-10-0-2-182.ap-northeast-2.compute.internal   <none>           <none>
pod/core-gateway-6c8cddf88f-rv87c      1/1     Running   0          3h24m   10.0.1.150   ip-10-0-1-127.ap-northeast-2.compute.internal   <none>           <none>
pod/service-account-697794f4dc-2xcfp   1/1     Running   0          4h27m   10.0.2.117   ip-10-0-2-131.ap-northeast-2.compute.internal   <none>           <none>
pod/service-account-697794f4dc-79c2p   1/1     Running   0          4h27m   10.0.1.139   ip-10-0-1-127.ap-northeast-2.compute.internal   <none>           <none>

NAME                      TYPE           CLUSTER-IP       EXTERNAL-IP                                                                          PORT(S)        AGE     SELECTOR
service/core-gateway      LoadBalancer   172.20.51.242    a68405a595e364c33b442ea5724708fc-b2c0661076cd8bc5.elb.ap-northeast-2.amazonaws.com   80:32411/TCP   3h24m   app=core-gateway
service/kubernetes        ClusterIP      172.20.0.1       <none>                                                                               443/TCP        9h      <none>
service/service-account   NodePort       172.20.224.161   <none>                                                                               80:32212/TCP   4h27m   app=service-account

NAME                              READY   UP-TO-DATE   AVAILABLE   AGE     CONTAINERS        IMAGES                                      SELECTOR
deployment.apps/core-gateway      2/2     2            2           3h24m   core-gateway      docker.io/laigasus/core-gateway:latest      app=core-gateway
deployment.apps/service-account   2/2     2            2           4h27m   service-account   docker.io/laigasus/service-account:latest   app=service-account

NAME                                         DESIRED   CURRENT   READY   AGE     CONTAINERS        IMAGES                                      SELECTOR
replicaset.apps/core-gateway-6c8cddf88f      2         2         2       3h24m   core-gateway      docker.io/laigasus/core-gateway:latest      app=core-gateway,pod-template-hash=6c8cddf88f
replicaset.apps/service-account-697794f4dc   2         2         2       4h27m   service-account   docker.io/laigasus/service-account:latest   app=service-account,pod-template-hash=697794f4dc
```